### PR TITLE
fix: use contract address in logs for contract deployments

### DIFF
--- a/libs/remix-lib/src/execution/logsManager.ts
+++ b/libs/remix-lib/src/execution/logsManager.ts
@@ -32,8 +32,8 @@ export class LogsManager {
               blockHash: bytesToHex(block.hash()),
               transactionHash: bytesToHex(tx.hash()),
               transactionIndex: '0x' + i.toString(16),
-              // TODO: if it's a contract deploy, it should be that address instead
-              address: log.address,
+              // Use contract address if it's a contract deployment
+              address: receipt.contractAddress || log.address,
               data: log.data,
               topics: log.topics
             }
@@ -170,8 +170,8 @@ export class LogsManager {
           blockHash: bytesToHex(log.block.hash()),
           transactionHash: bytesToHex(log.tx.hash()),
           transactionIndex: '0x' + log.txNumber.toString(16),
-          // TODO: if it's a contract deploy, it should be that address instead
-          address: log.log.address,
+          // Use contract address if it's a contract deployment
+          address: log.receipt && log.receipt.contractAddress ? log.receipt.contractAddress : log.log.address,
           data: log.log.data,
           topics: log.log.topics
         }
@@ -188,8 +188,8 @@ export class LogsManager {
           blockHash: bytesToHex(log.block.hash()),
           transactionHash: bytesToHex(log.tx.hash()),
           transactionIndex: '0x' + log.txNumber.toString(16),
-          // TODO: if it's a contract deploy, it should be that address instead
-          address: log.log.address,
+          // Use contract address if it's a contract deployment
+          address: log.receipt && log.receipt.contractAddress ? log.receipt.contractAddress : log.log.address,
           data: log.log.data,
           topics: log.log.topics
         })


### PR DESCRIPTION
This PR fixes the TODO comments in logsManager.ts by using the contract address from the transaction receipt when a transaction is a contract deployment.
Changes made:
- In checkBlock method: use receipt.contractAddress if available
- In getLogsByTxHash method: check for receipt.contractAddress and use it if available
- In getLogsFor method: check for receipt.contractAddress and use it if available