### PR TITLE
disable metamask e2e

### DIFF
--- a/apps/remix-ide-e2e/src/tests/ai_panel.test.ts
+++ b/apps/remix-ide-e2e/src/tests/ai_panel.test.ts
@@ -25,13 +25,9 @@ const tests = {
   'Should contain message starters #group1': function (browser: NightwatchBrowser) {
     browser
       .clickLaunchIcon('remixaiassistant')
-      .waitForElementVisible('*[data-id="remix-ai-assistant-starter-0"]')
-      .click('*[data-id="remix-ai-assistant-starter-0"]')
+      .waitForElementVisible('*[data-id="remix-ai-assistant-starter-beginner-0"]')
+      .click('*[data-id="remix-ai-assistant-starter-beginner-0"]')
       .waitForElementVisible('*[data-id="remix-ai-assistant"]')
-      .waitForElementVisible({
-        locateStrategy: 'xpath',
-        selector: '//*[contains(@class,"chat-bubble") and contains(.,"What is a modifier?")]'
-      })
       .waitForElementPresent({
         locateStrategy: 'xpath',
         selector: "//*[@data-id='remix-ai-streaming' and @data-streaming='false']",

--- a/apps/remix-ide-e2e/src/tests/metamask.test.ts
+++ b/apps/remix-ide-e2e/src/tests/metamask.test.ts
@@ -307,13 +307,13 @@ const tests = {
 const branch = process.env.CIRCLE_BRANCH
 const runTestsConditions = branch && (branch === 'master' || branch === 'remix_live' || branch.includes('remix_beta') || branch.includes('metamask'))
 
-if (!checkBrowserIsChrome(browser)) {
+// if (!checkBrowserIsChrome(browser)) {
   module.exports = {}
-} else {
-  module.exports = {
-    ...(branch ? (runTestsConditions ? tests : {}) : tests)
-  };
-}
+// } else {
+//   module.exports = {
+//     ...(branch ? (runTestsConditions ? tests : {}) : tests)
+//   };
+// }
 
 const EIP712_Example = {
   domain: {


### PR DESCRIPTION
From @bunsenstraat : 

Previously we were relying on an old version of chrome to allow the extension which is built for an older version to load properly. However this is quite unmaintainable ofc. In the long run.  So we see it failing.

The latest version of chrome doesn't allow extension loading so I used the 'chrome for testing' version. That one does allow loading extensions, but you can't find the tab opened for the extension besides using the generated extension ID, which you then have to hardcode. 
Previously we could switch tabs to the extension but that doesn't work anymore. Chrome prevents access to that tab in the window handles.

In previous version We used a special metamask build that would allow e2e to interact with the extension like filling in fields. In the new extension which I build from src using the gh action I made for that, that doesn't work anymore too. You can't control it anymore. No more JS filling in fields. 

- if we stay with an older version of metamask the e2e is pointless, same for the chrome browser
- continuously dealing with these complicated extension updates and security is a huge burden
- maybe after all this it's better just to give it a manual test during QA, just by default. 