### PR TITLE
fixed issue where Learneth tutorials could not be loaded via URL

### DIFF
--- a/apps/learneth/src/App.tsx
+++ b/apps/learneth/src/App.tsx
@@ -51,7 +51,9 @@ function App(): JSX.Element {
       callback: () => {
         // @ts-ignore
         remixClient.call('locale', 'currentLocale').then((locale: any) => {
-          loadRepo(locale)
+          if (!(window as any).startTutorialCalled) {
+            loadRepo(locale)
+          }
         })
         // @ts-ignore
         remixClient.on('locale', 'localeChanged', (locale: any) => {

--- a/apps/learneth/src/remix-client.ts
+++ b/apps/learneth/src/remix-client.ts
@@ -10,6 +10,7 @@ class RemixClient extends PluginClient {
   }
 
   startTutorial(name: any, branch: any, id: any): void {
+    (window as any).startTutorialCalled = true
     void router.navigate('/home')
     store.dispatch({
       type: 'workshop/loadRepo',


### PR DESCRIPTION
fixes #6381 

You just need to check whether the Solidity Beginner tutorial loads through the following URL:

[http://localhost:8080/?#activate=solidityUnitTesting,solidity,LearnEth\&call=LearnEth//startTutorial//ethereum/remix-workshops//master//soliditybeginner](http://localhost:8080/?#activate=solidityUnitTesting,solidity,LearnEth&call=LearnEth//startTutorial//ethereum/remix-workshops//master//soliditybeginner)
