### PR TITLE
Fix panel Enhancement on Focus

### DIFF
--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -40,6 +40,8 @@ export interface PromptAreaProps {
   maximizePanel: () => Promise<void>
   aiMode: 'ask' | 'edit'
   setAiMode: React.Dispatch<React.SetStateAction<'ask' | 'edit'>>
+  isMaximized: boolean
+  setIsMaximized: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const _paq = (window._paq = window._paq || [])
@@ -77,7 +79,9 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   textareaRef,
   maximizePanel,
   aiMode,
-  setAiMode
+  setAiMode,
+  isMaximized,
+  setIsMaximized
 }) => {
 
   return (
@@ -155,7 +159,9 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
             value={input}
             disabled={isStreaming}
             onFocus={() => {
-              maximizePanel()
+              if (!isMaximized) {
+                maximizePanel()
+              }
             }}
             onChange={e => {
               setInput(e.target.value)

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -667,7 +667,7 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
 
   const maximizePanel = async () => {
     await props.plugin.call('layout', 'maximisePinnedPanel')
-    setIsMaximized(true)
+    setIsMaximized(true) // ensured that expansion of the panel is stateful
   }
 
   return (

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -53,6 +53,7 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
   const [isOllamaFailureFallback, setIsOllamaFailureFallback] = useState(false)
   const [aiMode, setAiMode] = useState<'ask' | 'edit'>('ask')
   const [themeTracker, setThemeTracker] = useState(null)
+  const [isMaximized, setIsMaximized] = useState(false)
 
   const historyRef = useRef<HTMLDivElement | null>(null)
   const modelBtnRef = useRef(null)
@@ -666,6 +667,7 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
 
   const maximizePanel = async () => {
     await props.plugin.call('layout', 'maximisePinnedPanel')
+    setIsMaximized(true)
   }
 
   return (
@@ -759,6 +761,8 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
           textareaRef={textareaRef}
           aiMode={aiMode}
           setAiMode={setAiMode}
+          isMaximized={isMaximized}
+          setIsMaximized={setIsMaximized}
         />
       </section>
     </div>


### PR DESCRIPTION
Fix uncontrolled enhancement of remix ai assistant panel. So on remix.ethereum.org, when you expand the remix ai assistant, clicking in the input box resets the size of the plugin panel, as caught by @yann300. This pr fixes this issue by making the "enhancement" a stateful action.