### PR TITLE
Add support for custom solidity config file

### DIFF
--- a/apps/remix-ide/src/app/tabs/compile-tab.js
+++ b/apps/remix-ide/src/app/tabs/compile-tab.js
@@ -120,7 +120,7 @@ export default class CompileTab extends CompilerApiMixin(ViewPlugin) { // implem
 
   compile(fileName) {
     if (!isNative(this.currentRequest.from)) this.call('notification', 'toast', compileToastMsg(this.currentRequest.from, fileName))
-    super.compile(fileName)
+    return super.compile(fileName)
   }
 
   compileFile(event) {

--- a/libs/remix-ui/solidity-compiler/src/lib/api/compiler-api.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/api/compiler-api.ts
@@ -366,7 +366,9 @@ export const CompilerApiMixin = (Base) => class extends Base {
         if (this.currentFile && (this.currentFile.endsWith('.sol') || this.currentFile.endsWith('.yul'))) {
           if (await this.getAppParameter('hardhat-compilation')) this.compileTabLogic.runCompiler('hardhat')
           else if (await this.getAppParameter('truffle-compilation')) this.compileTabLogic.runCompiler('truffle')
-          else this.compileTabLogic.runCompiler(undefined)
+          else this.compileTabLogic.runCompiler(undefined).catch((error) => {
+            this.call('notification', 'toast', error.message)
+          })
         } else if (this.currentFile && this.currentFile.endsWith('.circom')) {
           await this.call('circuit-compiler', 'compile', this.currentFile)
         } else if (this.currentFile && this.currentFile.endsWith('.vy')) {

--- a/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
@@ -436,7 +436,15 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
     let externalCompType
     if (hhCompilation) externalCompType = 'hardhat'
     else if (truffleCompilation) externalCompType = 'truffle'
-    compileTabLogic.runCompiler(externalCompType)
+    compileTabLogic.runCompiler(externalCompType).catch((error) => {
+      tooltip(error.message)
+      compileIcon.current.classList.remove('remixui_bouncingIcon')
+      compileIcon.current.classList.remove('remixui_spinningIcon')
+      // @ts-ignore
+      props.setCompileErrors({ [currentFile]: { error: error.message } })
+      // @ts-ignore
+      props.setBadgeStatus({ [currentFile]: { key: 1, title: error.message, type: 'error' } })
+    })
   }
 
   const compileAndRun = () => {
@@ -448,7 +456,15 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
     if (hhCompilation) externalCompType = 'hardhat'
     else if (truffleCompilation) externalCompType = 'truffle'
     api.runScriptAfterCompilation(currentFile)
-    compileTabLogic.runCompiler(externalCompType)
+    compileTabLogic.runCompiler(externalCompType).catch((error) => {
+      tooltip(error.message)
+      compileIcon.current.classList.remove('remixui_bouncingIcon')
+      compileIcon.current.classList.remove('remixui_spinningIcon')
+      // @ts-ignore
+      props.setCompileErrors({ [currentFile]: { error: error.message } })
+      // @ts-ignore
+      props.setBadgeStatus({ [currentFile]: { key: 1, title: error.message, type: 'error' } })
+    })
   }
 
   const _updateVersionSelector = (version, customUrl = '', setQueryParameter = true) => {

--- a/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
@@ -285,6 +285,8 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
           updateCurrentVersion={updateCurrentVersion}
           configurationSettings={configurationSettings}
           solJsonBinData={state.solJsonBinData}
+          setCompileErrors={setCompileErrors}
+          setBadgeStatus={setBadgeStatus}
         />
         {/* "compileErrors[currentFile]['contracts']" field will not be there in case of compilation errors */}
         {contractsFile && contractsFile[currentFile] && contractsFile[currentFile].contractsDetails

--- a/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
@@ -21,7 +21,9 @@ export interface CompilerContainerProps {
   compiledFileName: string,
   updateCurrentVersion: any,
   configurationSettings: ConfigurationSettings,
-  solJsonBinData: iSolJsonBinData
+  solJsonBinData: iSolJsonBinData,
+  setCompileErrors: (errors: Record<string, CompileErrors>) => void
+  setBadgeStatus: (badgeStatus: Record<string, { key: string; title?: string; type?: string }>) => void
 }
 
 export interface ContractSelectionProps {

--- a/libs/remix-ui/tabs/src/lib/remix-ui-tabs.tsx
+++ b/libs/remix-ui/tabs/src/lib/remix-ui-tabs.tsx
@@ -498,7 +498,9 @@ export const TabsUI = (props: TabsUIProps) => {
       if (tabsState.currentExt === 'vy') {
         await props.plugin.call(compilerName, 'vyperCompileCustomAction')
       } else {
-        await props.plugin.call(compilerName, 'compile', path)
+        await props.plugin.call(compilerName, 'compile', path).catch((error) => {
+          props.plugin.call('notification', 'toast', error.message)
+        })
       }
 
     } catch (e) {


### PR DESCRIPTION
This PR enables a user to provide a path to a custom config file for solidity compilation in remix.config.json.

```
  "solidity-compiler": {
    "language": "Solidity",
    "settings": {
      "optimizer": {
        "enabled": true,
        "runs": 200
      }
    }
  }
  
OR

  "solidity-compiler": "contracts/compiler_config.json"
```