### PR TITLE
fix settings for treshold

### DIFF
--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -1054,6 +1054,7 @@ export class Blockchain extends Plugin {
       if (await this.call('terminal', 'isPanelHidden')) this.call('terminal', 'togglePanel')
       this._triggerEvent(eventName, [null, tx.from, tx.to, tx.data, tx.useCall, result, timestamp, payLoad])
 
+      console.log(result, tx, args)
       try {
         const isEnabled = await this.call('settings', 'get', 'settings/ai-feedback')
         const creditThreshold = await this.call('settings', 'get', 'settings/ai-feedback-credit-threshold')

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -20,6 +20,7 @@ const { txResultHelper } = helpers
 const { resultToRemixTx } = txResultHelper
 import * as packageJson from '../../../../package.json'
 import { formatUnits, parseUnits } from 'ethers'
+import { CompilerAbstract } from '@remix-project/remix-solidity'
 
 const profile = {
   name: 'blockchain',
@@ -1054,13 +1055,22 @@ export class Blockchain extends Plugin {
       if (await this.call('terminal', 'isPanelHidden')) this.call('terminal', 'togglePanel')
       this._triggerEvent(eventName, [null, tx.from, tx.to, tx.data, tx.useCall, result, timestamp, payLoad])
 
-      console.log(result, tx, args)
       try {
         const isEnabled = await this.call('settings', 'get', 'settings/ai-feedback')
         const creditThreshold = await this.call('settings', 'get', 'settings/ai-feedback-credit-threshold')
         if (isEnabled && !tx.to && !tx.useCall && !tx.isVM) {
           const auth = await this.call('auth', 'getCredits')
           if (auth && auth.balance > creditThreshold) {
+
+            let resolved: CompilerAbstract = await this.call('compilerArtefacts', 'getCompilerAbstractByContractName', args.data.contractName)
+            const sources = resolved.getSourceCode()
+            let source = ''
+            if (sources.target) {
+              source = sources.sources[sources.target].content
+            } else {
+              source = sources.sources[Object.keys(sources.sources)[0]].content
+            }
+
             const copy = { ...args.data }
             delete copy.contractBytecode
             delete copy.contractDeployedBytecode
@@ -1069,8 +1079,22 @@ export class Blockchain extends Plugin {
             const copyResult = { ...result }
             delete copyResult.data
 
-            const prompt = `The following contract has been deployed: ${JSON.stringify(copy)} , ${JSON.stringify(copyResult)}. Sum it up (deployment details) and propose me to go over some specific focussed areas.
-            Additionaly mention that RemixAI can load Skills to analyze the contract and provide insights by typing /load-skills in the AI chat. /gas-audit and /load-audit-checklist are also integrated to provide gas optimization and security audit insights. Go to settings => RemixAI Assistant => AI Feedback to disable automatic feedback feature.`
+            const prompt = `A contract was just deployed. Here is the deployment data: ${JSON.stringify(copy)}, ${JSON.stringify(copyResult)}.
+            ${source ? `Here is the contract source code:\n${source}` : ''}
+            ${args.data.contractABI ? `Here is the ABI:\n${JSON.stringify(args.data.contractABI)}` : ''}
+
+            Do the following, concisely:
+            1. Confirm the deployment (contract name, address, network, gas used) in 1-2 lines — don't over-elaborate here.
+            2. Based on the actual code/ABI, briefly note what this contract does and flag 1-3 specific things worth a closer look — e.g. access control patterns, external calls, payable functions, loops over dynamic arrays, upgradeability, or anything unusual you spot. Be specific to THIS contract, not generic advice.
+            3. Turn those flagged items into a concrete next-step offer, e.g. "I noticed an unbounded loop in withdrawAll() — want me to run /gas-audit on it?" rather than a generic feature list.
+
+            Then mention, briefly and only once:
+            - /load-skills lets RemixAI load specialized skills to analyze this contract further
+            - /gas-audit runs a gas optimization pass
+            - /load-audit-checklist runs a security checklist pass
+            - Automatic feedback can be disabled under Settings → RemixAI Assistant → AI Feedback
+
+            Keep the whole response tight — a wall of text defeats the purpose.`
             this.call('remixaiassistant', 'chatPipe', prompt, true, { source: 'udapp', presetId: 'deploy-contract' })
           }
         }

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -1081,6 +1081,7 @@ export class Blockchain extends Plugin {
 
             const prompt = `A contract was just deployed. Here is the deployment data: ${JSON.stringify(copy)}, ${JSON.stringify(copyResult)}.
             ${source ? `Here is the contract source code:\n${source}` : ''}
+            ${copy.funArgs && copy.funArgs.length ? `Here are the constructor arguments:\n${JSON.stringify(copy.funArgs)}` : ''}
             ${args.data.contractABI ? `Here is the ABI:\n${JSON.stringify(args.data.contractABI)}` : ''}
 
             Do the following, concisely:

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -1062,7 +1062,7 @@ export class Blockchain extends Plugin {
           const auth = await this.call('auth', 'getCredits')
           if (auth && auth.balance > creditThreshold) {
 
-            let resolved: CompilerAbstract = await this.call('compilerArtefacts', 'getCompilerAbstractByContractName', args.data.contractName)
+            const resolved: CompilerAbstract = await this.call('compilerArtefacts', 'getCompilerAbstractByContractName', args.data.contractName)
             const sources = resolved.getSourceCode()
             let source = ''
             if (sources.target) {

--- a/libs/remix-ui/settings/src/lib/settingsReducer.ts
+++ b/libs/remix-ui/settings/src/lib/settingsReducer.ts
@@ -26,7 +26,6 @@ const deepagentApiKeysConfig = config.get('settings/deepagent-api-keys-config') 
 const deepagentOpenrouterApiKey = config.get('settings/deepagent-openrouter-api-key') || ''
 const deepagentBedrockBearerToken = config.get('settings/deepagent-bedrock-bearer-token') || ''
 const enableCodeAnalysisPopover = config.get('settings/editor/code-analysis-popover')
-const aiFeedbackCreditThreshold = config.get('settings/ai-feedback-credit-threshold') || '0'
 const zkverifyApiKey = config.get('settings/zkverify-api-key') || ''
 const zkverifyNetwork = config.get('settings/zkverify-network') || 'testnet'
 
@@ -44,6 +43,7 @@ let showGas = config.get('settings/show-gas')
 let displayErrors = config.get('settings/display-errors')
 let saveEvmState = config.get('settings/save-evm-state')
 let aiFeedback = config.get('settings/ai-feedback')
+let aiFeedbackCreditThreshold = config.get('settings/ai-feedback-credit-threshold')
 
 if (!githubConfig && (githubUserName || githubEmail || gistAccessToken)) {
   config.set('settings/github-config', true)
@@ -109,6 +109,10 @@ if (typeof saveEvmState !== 'boolean') {
 if (typeof aiFeedback !== 'boolean') {
   config.set('settings/ai-feedback', true)
   aiFeedback = true
+}
+if (aiFeedbackCreditThreshold == null || aiFeedbackCreditThreshold === undefined) {
+  config.set('settings/ai-feedback-credit-threshold', 12000)
+  aiFeedbackCreditThreshold = 12000
 }
 
 let enableCodeAnalysisPopoverBoolean = enableCodeAnalysisPopover


### PR DESCRIPTION
From latest release on, transacting to a testnet/mainnet will trigger remixAI.
Settings for that feature are:
- enable/disable the feature
- minimum of credit left to trigger RemixAI upon transacting.

This PR fixes a bug, the treshold value is always 0 and RemixAI is never being summoned.

To run it, switch to a testnet and deploy a contract.