### PR TITLE
fix(remix-ai): forward pending sync operations to the cloud backend

### DIFF
--- a/libs/remix-ai-core/src/storage/interfaces.ts
+++ b/libs/remix-ai-core/src/storage/interfaces.ts
@@ -172,6 +172,7 @@ export interface IChatHistoryBackend {
 
   // Sync operations (for cloud backends)
   supportsSync(): boolean
+  queueSync?(operation: SyncOperation): void
   push?(): Promise<SyncResult>
   pull?(): Promise<SyncResult>
   getLastSyncTime?(): Promise<number | null>

--- a/libs/remix-ai-core/src/storage/storageManager.ts
+++ b/libs/remix-ai-core/src/storage/storageManager.ts
@@ -374,6 +374,7 @@ export class ChatHistoryStorageManager {
    */
   private queueSync(operation: SyncOperation): void {
     this.syncQueue.push(operation)
+    this.cloudBackend?.queueSync?.(operation)
 
     // Limit queue size to prevent memory issues (keep last 1000 operations)
     if (this.syncQueue.length > 1000) {

--- a/libs/remix-ai-core/test/storageManager.test.ts
+++ b/libs/remix-ai-core/test/storageManager.test.ts
@@ -1,0 +1,63 @@
+import tape from 'tape'
+import { ChatHistoryStorageManager } from '../src/storage/storageManager'
+import { IChatHistoryBackend, SyncOperation, SyncResult } from '../src/storage/interfaces'
+
+const successfulResult: SyncResult = {
+  success: true,
+  conversationsSynced: 1,
+  messagesSynced: 0,
+  errors: [],
+  timestamp: Date.now()
+}
+
+const createLocalBackend = (): IChatHistoryBackend => ({
+  name: 'local',
+  async init () {},
+  async isAvailable () { return true },
+  supportsSync () { return false },
+  async saveConversation () {},
+  async getConversations () { return [] },
+  async getConversation () { return null },
+  async updateConversation () {},
+  async deleteConversation () {},
+  async saveMessage () {},
+  async saveBatch () {},
+  async getMessages () { return [] }
+})
+
+tape('ChatHistoryStorageManager sync queue forwarding', t => {
+  t.test('forwards queued local operations to the cloud backend', async st => {
+    const queued: SyncOperation[] = []
+    const cloudBackend: IChatHistoryBackend = {
+      name: 'cloud',
+      async init () {},
+      async isAvailable () { return true },
+      supportsSync () { return true },
+      queueSync (operation) { queued.push(operation) },
+      async push () {
+        st.equal(queued.length, 1, 'push sees the operation queued by the manager')
+        return successfulResult
+      },
+      async saveConversation () {},
+      async getConversations () { return [] },
+      async getConversation () { return null },
+      async updateConversation () {},
+      async deleteConversation () {},
+      async saveMessage () {},
+      async saveBatch () {},
+      async getMessages () { return [] }
+    }
+
+    const manager = new ChatHistoryStorageManager(createLocalBackend(), cloudBackend)
+    await manager.init()
+    await manager.createConversation('default')
+
+    st.equal(queued.length, 1, 'cloud backend receives the pending operation')
+    st.equal(queued[0].type, 'conversation')
+    st.equal(queued[0].action, 'create')
+
+    await manager.syncToCloud()
+    manager.destroy()
+    st.end()
+  })
+})


### PR DESCRIPTION
## Description

Pending chat history sync operations were stored in `ChatHistoryStorageManager.syncQueue`, while the S3 backend's `push()` processed a separate `S3ChatHistoryBackend.syncQueue`.

Because the operations were never forwarded to the cloud backend, `push()` could process an empty queue and return a successful result without uploading the pending local changes. The manager would then clear its own queue, dropping those operations.

This change:

- adds an optional `queueSync()` method to `IChatHistoryBackend`;
- forwards operations queued by `ChatHistoryStorageManager` to the cloud backend;
- adds a regression test verifying that a locally created conversation is
  queued in the cloud backend before `push()` runs.

## Root cause

`ChatHistoryStorageManager` and `S3ChatHistoryBackend` maintained separate sync queues, but there was no forwarding path between them.

## Testing

Added a unit test covering the following flow:

1. Initialize the storage manager with local and fake cloud backends.
2. Create a local conversation.
3. Verify that the cloud backend receives a `conversation/create` operation.
4. Verify that the operation is available when `push()` is called.