### PR TITLE
fix(plugin-manager): persist permission changes on confirmation

### DIFF
--- a/apps/remix-ide-e2e/src/tests/pluginManager.test.ts
+++ b/apps/remix-ide-e2e/src/tests/pluginManager.test.ts
@@ -94,6 +94,102 @@ module.exports = {
         const finalCount = parseInt(result.value as string)
         browser.assert.equal(finalCount, initialAllCount, `Count should return to initial count after clearing filters.`)
       })
+  },
+
+  'Should only persist permission changes after confirmation #group1': function (browser: NightwatchBrowser) {
+    const permissionsButton = '[data-id="pluginManagerPermissionsButton"]'
+    const permissionCheckbox = '[data-id="permission-checkbox-fileManager-writeFile-e2ePlugin"]'
+    const removePermissionButton = '[data-id="pluginManagerSettingsRemovePermission-fileManager-writeFile-fileManager"]'
+
+    browser
+      .execute(function () {
+        localStorage.setItem(
+          'plugins/permissions',
+          JSON.stringify({
+            fileManager: {
+              writeFile: {
+                e2ePlugin: {
+                  allow: true
+                }
+              }
+            }
+          })
+        )
+      })
+      .click(permissionsButton)
+      .waitForElementVisible(permissionCheckbox)
+      .click(removePermissionButton)
+      .waitForElementNotPresent(permissionCheckbox)
+      .execute(
+        function () {
+          return JSON.parse(localStorage.getItem('plugins/permissions')).fileManager.writeFile.e2ePlugin.allow
+        },
+        [],
+        (result) => {
+          browser.assert.equal(result.value, true, 'Deleting a permission should remain a draft before confirmation.')
+        }
+      )
+      .click('[data-id="permissionsSettings-modal-footer-cancel-react"]')
+      .click(permissionsButton)
+      .waitForElementVisible(permissionCheckbox)
+      .assert.selected(permissionCheckbox, 'Cancel should restore a deleted permission.')
+      .click(permissionCheckbox)
+      .execute(
+        function () {
+          return JSON.parse(localStorage.getItem('plugins/permissions')).fileManager.writeFile.e2ePlugin.allow
+        },
+        [],
+        (result) => {
+          browser.assert.equal(result.value, true, 'Permission changes should remain a draft before confirmation.')
+        }
+      )
+      .click('[data-id="permissionsSettings-modal-footer-cancel-react"]')
+      .click(permissionsButton)
+      .waitForElementVisible(permissionCheckbox)
+      .assert.selected(permissionCheckbox, 'Cancel should restore the original permission.')
+      .click(permissionCheckbox)
+      .click('[data-id="permissionsSettings-modal-footer-ok-react"]')
+      .execute(
+        function () {
+          return JSON.parse(localStorage.getItem('plugins/permissions')).fileManager.writeFile.e2ePlugin.allow
+        },
+        [],
+        (result) => {
+          browser.assert.equal(result.value, false, 'OK should persist the permission change.')
+        }
+      )
+      .click(permissionsButton)
+      .waitForElementVisible(permissionCheckbox)
+      .click(permissionCheckbox)
+      .click('[data-id="permissionsSettings-modal-close"]')
+      .execute(
+        function () {
+          return JSON.parse(localStorage.getItem('plugins/permissions')).fileManager.writeFile.e2ePlugin.allow
+        },
+        [],
+        (result) => {
+          browser.assert.equal(result.value, false, 'Closing the dialog should discard the permission draft.')
+        }
+      )
+      .click(permissionsButton)
+      .waitForElementVisible(permissionCheckbox)
+      .assert.not.selected(permissionCheckbox, 'Closing the dialog should discard the in-memory permission draft.')
+      .click(permissionCheckbox)
+      .keys(browser.Keys.ESCAPE)
+      .waitForElementNotVisible('[data-id="permissionsSettingsModalDialogContainer-react"]')
+      .execute(
+        function () {
+          return JSON.parse(localStorage.getItem('plugins/permissions')).fileManager.writeFile.e2ePlugin.allow
+        },
+        [],
+        (result) => {
+          browser.assert.equal(result.value, false, 'Pressing Escape should discard the permission draft.')
+        }
+      )
+      .click(permissionsButton)
+      .waitForElementVisible(permissionCheckbox)
+      .assert.not.selected(permissionCheckbox, 'Pressing Escape should discard the in-memory permission draft.')
+      .click('[data-id="permissionsSettings-modal-footer-cancel-react"]')
       .end()
   }
 }

--- a/libs/remix-ui/plugin-manager/src/lib/components/permissionsSettings.tsx
+++ b/libs/remix-ui/plugin-manager/src/lib/components/permissionsSettings.tsx
@@ -9,19 +9,18 @@ import { CustomTooltip } from '@remix-ui/helper'
 
 function PermisssionsSettings() {
   const [modalVisibility, setModalVisibility] = useState<boolean>(true)
-  const [permissions, setPermissions] = useLocalStorage<PluginPermissions>('plugins/permissions', {} as PluginPermissions)
-  const [permissionCache, setpermissionCache] = useState<PluginPermissions>()
+  const [, persistPermissions] = useLocalStorage<PluginPermissions>('plugins/permissions', {} as PluginPermissions)
+  const [permissions, setPermissions] = useState<PluginPermissions>({} as PluginPermissions)
   const intl = useIntl()
   const closeModal = () => setModalVisibility(true)
   const openModal = () => {
     const currentValue = JSON.parse(window.localStorage.getItem('plugins/permissions') || '{}')
-    setpermissionCache(currentValue)
     setPermissions(currentValue)
-    setModalVisibility(!modalVisibility)
+    setModalVisibility(false)
   }
 
-  const cancel = () => {
-    setPermissions(permissionCache)
+  const save = () => {
+    persistPermissions(permissions)
   }
 
   const getState = (targetPlugin: string, funcName: string, pluginName: string) => {
@@ -29,25 +28,36 @@ function PermisssionsSettings() {
   }
 
   const handleCheckboxClick = (targetPlugin: string, funcName: string, pluginName: string) => {
-    setPermissions((permissions) => {
-      permissions[targetPlugin][funcName][pluginName].allow = !permissions[targetPlugin][funcName][pluginName].allow
-      return permissions
-    })
+    setPermissions((previous) => ({
+      ...previous,
+      [targetPlugin]: {
+        ...previous[targetPlugin],
+        [funcName]: {
+          ...previous[targetPlugin][funcName],
+          [pluginName]: {
+            ...previous[targetPlugin][funcName][pluginName],
+            allow: !previous[targetPlugin][funcName][pluginName].allow
+          }
+        }
+      }
+    }))
   }
 
   function clearFunctionPermission(targetPlugin: string, funcName: string, pluginName: string) {
-    setPermissions((permissions) => {
-      delete permissions[targetPlugin][funcName][pluginName]
-      if (Object.keys(permissions[targetPlugin][funcName]).length === 0) delete permissions[targetPlugin][funcName]
-      if (Object.keys(permissions[targetPlugin]).length === 0) delete permissions[targetPlugin]
-      return permissions
+    setPermissions((previous) => {
+      const next = JSON.parse(JSON.stringify(previous)) as PluginPermissions
+      delete next[targetPlugin][funcName][pluginName]
+      if (Object.keys(next[targetPlugin][funcName]).length === 0) delete next[targetPlugin][funcName]
+      if (Object.keys(next[targetPlugin]).length === 0) delete next[targetPlugin]
+      return next
     })
   }
 
   function clearTargetPermission(targetPlugin: string) {
-    setPermissions((permissions) => {
-      delete permissions[targetPlugin]
-      return permissions
+    setPermissions((previous) => {
+      const next = { ...previous }
+      delete next[targetPlugin]
+      return next
     })
   }
 
@@ -115,7 +125,7 @@ function PermisssionsSettings() {
       <ModalDialog
         id="permissionsSettings"
         handleHide={closeModal}
-        cancelFn={cancel}
+        okFn={save}
         hide={modalVisibility}
         title={intl.formatMessage({
           id: 'pluginManager.pluginManagerPermissions'


### PR DESCRIPTION
## Summary

Fixes https://github.com/remix-project-org/remix-project/issues/7597

- make the permissions dialog's header close action follow the cancellation path
- restore the permission state captured when the dialog was opened
- keep the existing OK behavior unchanged
- add coverage for closing the dialog after toggling or deleting permissions

## Problem

Permission edits are persisted to localStorage immediately. The footer Cancel button invokes `cancelFn`, which restores the original permissions, but the header X button only hides the modal.

This causes unconfirmed changes to remain persisted when users close the dialog using the X button.

