### PR TITLE
fix(remix-ide): give the starknet plugin a long queueTimeout so its activation permission modal survives

### DIFF
--- a/apps/remix-ide/src/remixEngine.js
+++ b/apps/remix-ide/src/remixEngine.js
@@ -38,6 +38,7 @@ export class RemixEngine extends Engine {
     if (name === 'resolutionIndex') return { queueTimeout: 60000 * 2 }
     if (name === 'circom') return { queueTimeout: 60000 * 4 }
     if (name === 'noir-compiler') return { queueTimeout: 60000 * 4 }
+    if (name === 'starknet') return { queueTimeout: 60000 * 4 }
     //if (name === 'sso') return { queueTimeout: 60000 * 4 }
     return { queueTimeout: 10000 }
   }

--- a/apps/remix-ide/src/remixEngine.spec.js
+++ b/apps/remix-ide/src/remixEngine.spec.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const { RemixEngine } = require('./remixEngine')
+
+describe('RemixEngine.setPluginOption', () => {
+  it('gives the starknet plugin a queueTimeout longer than the 10s default so its permission modal survives', () => {
+    const option = new RemixEngine().setPluginOption({ name: 'starknet' })
+    assert.ok(option.queueTimeout > 10000, `starknet queueTimeout ${option.queueTimeout} should exceed the 10s default`)
+  })
+
+  it('gives starknet the same queueTimeout as the hardhat and truffle plugins', () => {
+    const engine = new RemixEngine()
+    const starknet = engine.setPluginOption({ name: 'starknet' }).queueTimeout
+    const hardhat = engine.setPluginOption({ name: 'hardhat' }).queueTimeout
+    assert.strictEqual(starknet, hardhat)
+  })
+})


### PR DESCRIPTION
Fixes #7610

## Root cause

`RemixEngine.setPluginOption()` in `apps/remix-ide/src/remixEngine.js` has no entry for the `starknet` plugin, so it falls through to the default `{ queueTimeout: 10000 }` (line 42). During starknet plugin activation the permission-request chain (`starknet -> filePanel.getWorkspaces -> manager.canCall -> permissionhandler.askPermission -> notification.modal`) can sit open while the user reads the modal; after 10s the engine times out the queued permission calls, the plugin init aborts and the modal is left orphaned until Remix reloads.

## Fix

Whitelist `starknet` with the same long `queueTimeout` already used for the other compile/activation plugins (`hardhat`, `truffle`, `localPlugin`, `sourcify`, ...):

```js
if (name === 'starknet') return { queueTimeout: 60000 * 4 }
```

(4 minutes), so the permission prompt has time to be answered.

## Tests

Added `apps/remix-ide/src/remixEngine.spec.js`, a pure-function unit test asserting `setPluginOption({ name: 'starknet' })` returns a `queueTimeout` greater than the 10s default and equal to the `hardhat` entry.

The IDE app has no wired Nx test target, so the spec runs with the repo's mocha + babel directly:

```
npx mocha --require @babel/register apps/remix-ide/src/remixEngine.spec.js
```