### PR TITLE
fix(import-resolver): keep fetched imports under .deps

### DIFF
--- a/libs/remix-import-resolver/src/adapters/node-io-adapter.ts
+++ b/libs/remix-import-resolver/src/adapters/node-io-adapter.ts
@@ -5,6 +5,7 @@ import { toHttpUrls } from '../utils/to-http-url'
 import {
   isHttpUrl,
   isDepsPath,
+  jailDepsPath,
   DEPS_DIR,
   DEPS_HTTP_DIR,
   DEPS_NPM_DIR,
@@ -24,8 +25,9 @@ export class NodeIOAdapter implements IOAdapter {
   }
 
   async setFile(path: string, content: string): Promise<void> {
-    await fs.mkdir(dirname(path), { recursive: true })
-    await fs.writeFile(path, content, 'utf8')
+    const dest = jailDepsPath(path)
+    await fs.mkdir(dirname(dest), { recursive: true })
+    await fs.writeFile(dest, content, 'utf8')
   }
 
   async exists(path: string): Promise<boolean> {
@@ -84,6 +86,7 @@ export class NodeIOAdapter implements IOAdapter {
       // Ensure all resolver-managed artifacts live under .deps
       dest = `${DEPS_DIR}${dest}`
     }
+    dest = jailDepsPath(dest)
 
     // If cache is enabled and file exists, return cached content from disk
     if (this.cacheEnabled) {

--- a/libs/remix-import-resolver/src/adapters/remix-plugin-adapter.ts
+++ b/libs/remix-import-resolver/src/adapters/remix-plugin-adapter.ts
@@ -3,6 +3,7 @@ import { toHttpUrls } from '../utils/to-http-url'
 import {
   isHttpUrl,
   isDepsPath,
+  jailDepsPath,
   DEPS_DIR,
   DEPS_HTTP_DIR,
   DEPS_NPM_DIR,
@@ -46,7 +47,7 @@ export class RemixPluginAdapter implements IOAdapter {
   }
 
   async setFile(path: string, content: string): Promise<void> {
-    await this.plugin.call('fileManager', 'setFile', path, content)
+    await this.plugin.call('fileManager', 'setFile', jailDepsPath(path), content)
   }
 
   async exists(path: string): Promise<boolean> {
@@ -107,6 +108,7 @@ export class RemixPluginAdapter implements IOAdapter {
     } else if (!isDepsPath(dest)) {
       dest = `${DEPS_DIR}${dest}`
     }
+    dest = jailDepsPath(dest)
 
     // Update .raw_paths.json mapping regardless of cache hit/miss
     await this.updateRawPathsMapping(url, dest)
@@ -126,7 +128,7 @@ export class RemixPluginAdapter implements IOAdapter {
     // Fetch content directly using our simple translator
     const content: string = await this.fetch(url)
     console.log(`Fetched content from ${url}, saving to ${dest}`)
-    await this.plugin.call('fileManager', 'setFile', dest, content)
+    await this.setFile(dest, content)
 
     // Return content to the resolver (it expects the fetched file contents, not a path)
     return content

--- a/libs/remix-import-resolver/src/constants/import-patterns.ts
+++ b/libs/remix-import-resolver/src/constants/import-patterns.ts
@@ -72,6 +72,36 @@ export function isDepsPath(path: string): boolean {
   return path.startsWith(DEPS_DIR)
 }
 
+/**
+ * Canonicalize a resolver save path and reject anything that leaves `.deps`.
+ * `path.join` / `path.normalize` treat `src/../..` as a write outside the tree.
+ * Keep this string-only so the browser adapter does not pull Node `path`.
+ */
+export function jailDepsPath(dest: string): string {
+  if (!dest || dest.includes('\0')) {
+    throw new Error(`Import save path is invalid: ${dest}`)
+  }
+  if (dest.startsWith('/') || /^[A-Za-z]:[\\/]/.test(dest)) {
+    throw new Error(`Import save path must be relative: ${dest}`)
+  }
+  const out: string[] = []
+  for (const part of dest.replace(/\\/g, '/').split('/')) {
+    if (!part || part === '.') continue
+    if (part === '..') {
+      if (out.length === 0) {
+        throw new Error(`Import save path escapes .deps: ${dest}`)
+      }
+      out.pop()
+      continue
+    }
+    out.push(part)
+  }
+  if (out[0] !== '.deps') {
+    throw new Error(`Import save path escapes .deps: ${dest}`)
+  }
+  return out.join('/')
+}
+
 /** Check if a path is in the npm deps directory */
 export function isNpmDepsPath(path: string): boolean {
   return path.startsWith(DEPS_NPM_DIR)

--- a/libs/remix-import-resolver/src/index.ts
+++ b/libs/remix-import-resolver/src/index.ts
@@ -64,6 +64,7 @@ export {
   normalizeSwarmUrl
 } from './utils/url-normalizer'
 export { toHttpUrl, toHttpUrls } from './utils/to-http-url'
+export { jailDepsPath } from './constants/import-patterns'
 
 // Type-safe path types and common interfaces
 export type {

--- a/libs/remix-import-resolver/test/jail-deps-path.spec.ts
+++ b/libs/remix-import-resolver/test/jail-deps-path.spec.ts
@@ -1,0 +1,27 @@
+/// <reference types="mocha" />
+import { expect } from 'chai'
+import { jailDepsPath, normalizeRawGithubUrl } from '../src'
+
+describe('jailDepsPath', () => {
+  it('keeps a normal GitHub save path under .deps', () => {
+    expect(jailDepsPath('.deps/github/openzeppelin/openzeppelin-contracts@v5.0.2/contracts/token/ERC20/ERC20.sol'))
+      .to.equal('.deps/github/openzeppelin/openzeppelin-contracts@v5.0.2/contracts/token/ERC20/ERC20.sol')
+  })
+
+  it('rejects a GitHub filePath that walks out of .deps', () => {
+    const raw = normalizeRawGithubUrl(
+      'https://raw.githubusercontent.com/openzeppelin/openzeppelin-contracts/v5.0.2/../../../../tmp/remix-import-escape-probe.sol'
+    )
+    expect(raw?.targetPath).to.include('..')
+    expect(() => jailDepsPath(raw!.targetPath)).to.throw('escapes .deps')
+  })
+
+  it('rejects an HTTP pathname that walks out of .deps', () => {
+    expect(() => jailDepsPath('.deps/http/example.com/../../../tmp/remix-import-escape-probe.sol'))
+      .to.throw('escapes .deps')
+  })
+
+  it('rejects an absolute save path', () => {
+    expect(() => jailDepsPath('/tmp/remix-import-escape-probe.sol')).to.throw('must be relative')
+  })
+})


### PR DESCRIPTION
## Summary

`normalizeRawGithubUrl` builds `.deps/github/<owner>/<repo>@<ref>/<filePath>` from the URL as-is. A Solidity import of `https://raw.githubusercontent.com/org/repo/ref/../../../../tmp/pwned.sol` therefore saves outside `.deps`. The HTTP fallback does the same with the URL pathname.

The attacker already controls the import URL (gist, shared contract, or `remix-flatten` input). Prefixing `.deps/` does not dominate `..`.

`jailDepsPath` fail-closes before `setFile` on both the Node and Remix plugin adapters. Normal OpenZeppelin GitHub saves are unchanged.

## Test plan

- [x] `mocha test/jail-deps-path.spec.ts test/url-normalizer.spec.ts` (9/9)
- [x] Revert-tested: identity `jailDepsPath` makes the three reject cases fail (`expected [Function] to throw`)

Made with [Cursor](https://cursor.com)