### PR TITLE
don't report automatic domain redirects to Matomo

### DIFF
--- a/apps/remix-ide/src/app/components/preload.tsx
+++ b/apps/remix-ide/src/app/components/preload.tsx
@@ -242,19 +242,6 @@ export const Preload = (props: PreloadProps) => {
     }
   }
 
-  // Navigation cancels in-flight tracker requests, so ask Matomo for a beacon first.
-  const trackDomainRedirect = (toDomain: string) => {
-    try {
-      const paq = (window as any)._paq
-      if (Array.isArray(paq)) paq.push(['alwaysUseSendBeacon'])
-    } catch (_) { /* tracker not loaded */ }
-    trackMatomoEvent?.({ category: 'App', action: 'FreshUserDomainRedirect', name: toDomain, isClick: false })
-  }
-
-  const trackConfirmedRedirect = (toDomain: string) => {
-    trackMatomoEvent?.({ category: 'App', action: 'ConfirmedMigrationRedirect', name: toDomain, isClick: false })
-  }
-
   useEffect(() => {
     // Remove pre-splash as soon as React preloader mounts
     try {
@@ -273,7 +260,10 @@ export const Preload = (props: PreloadProps) => {
 
     // A user who confirmed the move is sent on before anything else loads.
     // Reads localStorage only, so everyone else pays nothing for it.
-    if (redirectConfirmedVisitor(trackConfirmedRedirect)) return
+    //
+    // Not tracked: the visitor is counted again on the new domain under a new
+    // visitor id, so reporting it here would double-count the same person.
+    if (redirectConfirmedVisitor()) return
 
     async function loadStorage() {
       ; (await remixFileSystems.current.addFileSystem(remixIndexedDB.current)) || trackMatomoEvent?.({ category: 'Storage', action: 'error', name: 'indexedDB not supported', isClick: false })
@@ -285,7 +275,7 @@ export const Preload = (props: PreloadProps) => {
       // Last moment at which "fresh" is still knowable: the IDE creates a
       // default workspace as soon as it boots.
       setVisitFreshness(isFreshBrowser(!!remixIndexedDB.current.hasWorkSpaces || !!localStorageFileSystem.current.hasWorkSpaces))
-      if (await maybeRedirectFreshVisitor(trackDomainRedirect)) return
+      if (await maybeRedirectFreshVisitor()) return
 
       remixIndexedDB.current.loaded && (remixIndexedDB.current.hasWorkSpaces || !localStorageFileSystem.current.hasWorkSpaces ? await setFileSystems() : setShowDownloader(true))
       !remixIndexedDB.current.loaded && (await setFileSystems())

--- a/apps/remix-ide/src/app/components/preload.tsx
+++ b/apps/remix-ide/src/app/components/preload.tsx
@@ -13,7 +13,6 @@ import './styles/preload.css'
 import isElectron from 'is-electron'
 import { initEndpoints } from '@remix-endpoints-helper'
 import { isFreshBrowser, maybeRedirectFreshVisitor, setVisitFreshness } from '../utils/freshUserRedirect'
-import { redirectConfirmedVisitor } from '../utils/migrationConfirm'
 
 // _paq.push(['trackEvent', 'App', 'Preload', 'start'])
 
@@ -257,13 +256,6 @@ export const Preload = (props: PreloadProps) => {
     // Started here rather than in loadAppComponent so the redirect checks below
     // resolve against the right API; the call is deduped.
     initEndpoints()
-
-    // A user who confirmed the move is sent on before anything else loads.
-    // Reads localStorage only, so everyone else pays nothing for it.
-    //
-    // Not tracked: the visitor is counted again on the new domain under a new
-    // visitor id, so reporting it here would double-count the same person.
-    if (redirectConfirmedVisitor()) return
 
     async function loadStorage() {
       ; (await remixFileSystems.current.addFileSystem(remixIndexedDB.current)) || trackMatomoEvent?.({ category: 'Storage', action: 'error', name: 'indexedDB not supported', isClick: false })

--- a/apps/remix-ide/src/index.tsx
+++ b/apps/remix-ide/src/index.tsx
@@ -1,14 +1,23 @@
 // eslint-disable-next-line no-use-before-define
 import React from 'react'
 import './index.css'
+import isElectron from 'is-electron'
 import { MatomoManager } from './app/matomo/MatomoManager'
 import { autoInitializeMatomo } from './app/matomo/MatomoAutoInit'
 import { createMatomoConfig } from './app/matomo/MatomoConfig'
 import { createTrackingFunction } from './app/utils/TrackingFunction'
 import { setupThemeAndLocale } from './app/utils/AppSetup'
 import { renderApp } from './app/utils/AppRenderer'
+import { redirectConfirmedVisitor } from './app/utils/migrationConfirm'
 
 ; (async function () {
+  // Someone who confirmed the move leaves before anything else starts, and in
+  // particular before Matomo initialises: its initial page view would record
+  // this visit on the origin they are leaving, and the destination counts them
+  // again under a new visitor id. Reads localStorage only.
+  // The OAuth popup runs on whichever origin opened it, so leave it alone.
+  if (!isElectron() && !window.location.hash.includes('source=github') && redirectConfirmedVisitor()) return
+
   // Create Matomo configuration
   const matomoConfig = createMatomoConfig();
   const matomoManager = new MatomoManager(matomoConfig);

--- a/libs/remix-api/src/lib/plugins/matomo/events/plugin-events.ts
+++ b/libs/remix-api/src/lib/plugins/matomo/events/plugin-events.ts
@@ -51,12 +51,12 @@ export interface AppEvent extends MatomoEventBase {
     | 'PreloadError'
     | 'queryParams-calls'
     | 'queryParams-migrate'
-    | 'ConfirmedMigrationRedirect'
+    // Automatic domain redirects are deliberately not tracked: the visitor is
+    // counted again on the destination under a new visitor id.
     | 'MigrationConfirmed'
     | 'MigrationConfirmFailed'
     | 'MobileRedirect'
-    | 'MobileRedirectOverride'
-    | 'FreshUserDomainRedirect';
+    | 'MobileRedirectOverride';
 }
 
 export interface MigrateEvent extends MatomoEventBase {


### PR DESCRIPTION
The migration redirects fired an event just before navigating to the new domain. Because Matomo identifies visitors per domain, that same person is then counted again on the destination under a fresh visitor id, so every automatic redirect inflated the visitor count with a duplicate.

Drops the tracking from both automatic paths — the confirmed-visitor redirect and the fresh-visitor redirect — and removes the two now-unused action names from the AppEvent union, with a note recording why so they don't come back.

Deliberate user actions are still tracked: MigrationConfirmed / MigrationConfirmFailed on the confirmation page, the help modal's domainMigration* events, and the wizard's Backup events. The onRedirect callbacks stay on the redirect helpers, just unwired from Matomo.